### PR TITLE
Update .gitignore to exclude luamidi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@
 *.exe
 *.out
 *.app
+
+luamidi


### PR DESCRIPTION
If you don't want to repeat 454246cb689f5d0989b9199424bf6db055ea3efd, you can add luamidi to your .gitignore file.

You can read more about the .gitignore file on https://git-scm.com/docs/gitignore.